### PR TITLE
add shell script that download Lint package

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -1,0 +1,1 @@
+julia -e 'Pkg.clone("Lint")'


### PR DESCRIPTION
add shell script for ``julia -e "Pkg.clone('Lint')"``. Make plugin manager hooks easier (for example for [vim-plug](https://github.com/junegunn/vim-plug)) : remove nested quote issues.